### PR TITLE
Updates to make mipOS compile with current SDCC

### DIFF
--- a/examples/stm8/main.c
+++ b/examples/stm8/main.c
@@ -26,9 +26,16 @@ void assert_failed(unsigned char* file, unsigned long line)
 /* -------------------------------------------------------------------------- */
 
 /* TODO: implement putchar required by vprintf */ 
+
+#if defined(__SDCC) && __SDCC_REVISION < 9624 // Old SDCC weirdness
 void putchar(char c) {
     (void) c;
 }
+#else // Standard C
+int putchar(int c) {
+    return (c);
+}
+#endif
 
 
 /* --------------------------------------------------------------------------- */

--- a/mipos/arch/stm8/mipos_bsp_stm8.h
+++ b/mipos/arch/stm8/mipos_bsp_stm8.h
@@ -59,7 +59,7 @@ int mipos_bsp_check_reset_type( void );
 /* -------------------------------------------------------------------------- */
 
 // Small Device C Compiler
-#elif defined(SDCC)
+#elif defined(__SDCC)
 
 #define mipos_set_sp(__N_SP) __asm \
   LDW X, _ ## __N_SP + 0     \

--- a/mipos/arch/stm8/mipos_bsp_stm8s.c
+++ b/mipos/arch/stm8/mipos_bsp_stm8s.c
@@ -73,7 +73,7 @@ void mipos_bsp_setup_reset_and_wd(void)
   * @retval
   * None
   */
-#ifdef SDCC
+#ifdef __SDCC
 INTERRUPT_HANDLER(TIM4_UPD_OVF_IRQHandler, 23)
 #elif defined( _COSMIC_ )
 @far @interrupt void TIM4_UPD_OVF_IRQHandler(void)
@@ -112,7 +112,7 @@ void mipos_bsp_create_hw_rtc_timer(void)
 
 /* -------------------------------------------------------------------------- */
 
-#ifdef SDCC
+#ifdef __SDCC
 void * mipos_get_sp()
 {
    __asm

--- a/mipos/arch/stm8/stm8s_lib/inc/stm8s.h
+++ b/mipos/arch/stm8/stm8s_lib/inc/stm8s.h
@@ -84,7 +84,7 @@
  #define _RAISONANCE_
 #elif defined(__ICCSTM8__)
  #define _IAR_
-#elif defined(SDCC)
+#elif defined(__SDCC)
  #define _SDCC_
 #else
  #error "Unsupported Compiler!"          /* Compiler defines not found */


### PR DESCRIPTION
I noticed that mipOS relies on the behaviour of older SDCC in some places.
These updates should make mipOS compile both with older and current SDCC.
With these changes I can compile mipOS with SDCC 3.7.2 #10502.

Philipp
